### PR TITLE
stablize the "Sample SIMAP Use Cases" preamble

### DIFF
--- a/draft-ietf-nmop-simap-concept.md
+++ b/draft-ietf-nmop-simap-concept.md
@@ -183,31 +183,7 @@ SIMAP data:
 
 # Sample SIMAP Use Cases
 
-The following are sample use cases that require SIMAP:
-
-* Inventory queries
-+ Service placement feasibility checks
-+ Service-> subservice -> resource
-+ Resource -> subservice -> service
-+ Intent/service assurance
-+ Service E2E and per-link KPIs on SIMAP (connectivity status, high-availability, delay, jitter, and loss)
-+ Capacity planning
-+ Network design
-+ Network Simulation and Emulation
-+ Traffic Engineering
-+ Postmortem Replay
-+ Closed-loop
-- Network Digital Twin (NDT)
-
-Overall, the SIMAP is needed to provide the mechanism to connect data islands from the core multi-layered topology.
-It is a solution feasible and useful in the short-term for the existing operations use cases, but it is also a
-requirement for the SIMAP.
-
-> The following subsections include some initial use case descriptions to initiate the discussion about what type of info
-> is needed to describe the use cases in the context of SIMAP.
-> The next version of the draft will include more info on these use cases and more input from the operators,
-> from the perspective of what the value of the SIMAP for each use case is and how the SIMAP API can be used.
-> This will also clarify if only read and if/when write interface is needed per use case.
+The following subsections provides a non-exhaustive list of SIMAP use cases.
 
 ## Inventory Queries
 


### PR DESCRIPTION
no need to be verbose, especially that the use cases have decent description text now.